### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/springbok.yml
+++ b/.github/workflows/springbok.yml
@@ -13,4 +13,4 @@ jobs:
         run: pip install git+https://github.com/antmicro/tuttest
 
       - name: Run tuttest
-        run: tuttest README.md | bash -e -
+        run: tuttest README.md | grep -v sim_springbok | bash -e -

--- a/.github/workflows/springbok.yml
+++ b/.github/workflows/springbok.yml
@@ -1,0 +1,16 @@
+name: Springbok README tests
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Install tuttest
+        run: pip install git+https://github.com/antmicro/tuttest
+
+      - name: Run tuttest
+        run: tuttest README.md | bash -e -

--- a/build_tools/install_toolchain.sh
+++ b/build_tools/install_toolchain.sh
@@ -41,7 +41,7 @@ echo "Download ${TOOLCHAIN_TARBALL} from GCS..."
 DOWNLOAD_URL="https://storage.googleapis.com/shodan-public-artifacts/${TOOLCHAIN_TARBALL}"
 mkdir -p "${DOWNLOAD_DIR}"
 
-wget -P "${DOWNLOAD_DIR}" "${DOWNLOAD_URL}"
+wget --progress=dot:giga -P "${DOWNLOAD_DIR}" "${DOWNLOAD_URL}"
 wget -P "${DOWNLOAD_DIR}" "${DOWNLOAD_URL}.sha256sum"
 pushd "${DOWNLOAD_DIR}" > /dev/null
 try sha256sum -c "${TOOLCHAIN_TARBALL}.sha256sum"


### PR DESCRIPTION
This PR adds a simple GitHub Actions test running the flow from README using [Tuttest](https://github.com/antmicro/tuttest/).

I explicitly skipped running Renode interactively, but otherwise this runs all other commands.

Additionaly I added missing Python dependencies and reduced some wget logs (polluting CI very heavily) 