### PR TITLE
Specify core in ControlBlock GetRegistrationPoints

### DIFF
--- a/sim/config/infrastructure/SpringbokRiscV32.cs
+++ b/sim/config/infrastructure/SpringbokRiscV32.cs
@@ -284,7 +284,7 @@ namespace Antmicro.Renode.Peripherals.CPU
                         {
                             this.Log(LogLevel.Noisy, "Resetting core.");
                             Core.Reset();
-                            ulong startAddress = (val & ~(ulong)Mode.Mask) + Machine.SystemBus.GetRegistrationPoints(IMem).First().Range.StartAddress;
+                            ulong startAddress = (val & ~(ulong)Mode.Mask) + Machine.SystemBus.GetRegistrationPoints(IMem, Core).First().Range.StartAddress;
                             this.Log(LogLevel.Noisy, "Setting PC to 0x{0:X}.", startAddress);
                             Core.PC = startAddress;
                         }


### PR DESCRIPTION
This clarifies the core that tries to access registration points.

It's important for setups with core-specific registrations.

For most cases this is effectively a nop.