### PR TITLE
Bump IREE release to 20220218.434

### DIFF
--- a/build_tools/download_iree_compiler.py
+++ b/build_tools/download_iree_compiler.py
@@ -65,7 +65,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Download IREE host compiler from snapshot releases")
     parser.add_argument(
-        "--tag_name", action="store", default="candidate-20230124.407",
+        "--tag_name", action="store", default="candidate-20230218.434",
         help="snapshot tag to download. If not set, default to the one synced to third_party/iree commit.")
     parser.add_argument(
         "--release_url", action="store",

--- a/cmake/springbok_modules.cmake
+++ b/cmake/springbok_modules.cmake
@@ -120,7 +120,6 @@ function(springbok_modules)
       "${_INPUT_FILENAME}"
   )
 
-  # TODO(#10810): Only add `INLINE_HAL` option to non-emitc target for now.
   if (${_RULE_VMVX})
     springbok_vmvx_module(
       NAME
@@ -143,9 +142,11 @@ function(springbok_modules)
         "${_INPUT_FILENAME}"
       FLAGS
         ${_RULE_FLAGS}
+      "${_INLINE_HAL_ARG}"
       EMITC
       DEPENDS
         "${_INPUT_FILENAME}"
     )
   endif()
+
 endfunction()

--- a/samples/simple_vec_mul/CMakeLists.txt
+++ b/samples/simple_vec_mul/CMakeLists.txt
@@ -27,6 +27,7 @@ springbok_modules(
     "samples_simple_vec_mul_simple_float_mul"
   FLAGS
     "-iree-input-type=mhlo"
+    "-riscv-v-fixed-length-vector-lmul-max=8"
   VMVX
   INLINE_HAL
 )
@@ -40,7 +41,6 @@ springbok_modules(
     "samples_simple_vec_mul_simple_int_mul"
   FLAGS
     "-iree-input-type=mhlo"
-    "-riscv-v-vector-bits-min=512"
     "-riscv-v-fixed-length-vector-lmul-max=8"
   VMVX
   INLINE_HAL
@@ -63,7 +63,6 @@ springbok_modules(
 #
 # to increase it.
 
-# TODO(#10810): Only use inline HAL with non-emitc target for now.
 iree_cc_binary(
   NAME
     simple_float_vec_mul_bytecode_vmvx
@@ -85,7 +84,7 @@ iree_cc_binary(
     "float_vec.c"
   DEPS
     ::simple_float_mul_c_module_vmvx_emitc
-    samples::util::util_vmvx
+    samples::util::util_vmvx_inline
   LINKOPTS
     "LINKER:--defsym=__stack_size__=20k"
   COPTS
@@ -122,7 +121,6 @@ iree_cc_binary(
     "-DBUILD_EMITC"
 )
 
-# TODO(#10810): Only use inline HAL with non-emitc target for now.
 iree_cc_binary(
   NAME
     simple_int_vec_mul_bytecode_vmvx
@@ -144,7 +142,7 @@ iree_cc_binary(
     "int_vec.c"
   DEPS
     ::simple_int_mul_c_module_vmvx_emitc
-    samples::util::util_vmvx
+    samples::util::util_vmvx_inline
   LINKOPTS
     "LINKER:--defsym=__stack_size__=20k"
   COPTS


### PR DESCRIPTION
Also enable emitc inlineHAL.

Other inlineHAL changes (e.g.,  building other inlineHAL targets) wold come later at a separate commit.